### PR TITLE
Various fixes around try..catch[..finally] support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# Pausable
+
+Pause and resume JavaScript code from arbitrary places.
+
+## Installation
+
+```shell script
+$ npm install pausable
+```
+
+## Usage
+
+```javascript
+let pausable = require('pausable');
+```
+
+### Execute code where the top level can pause
+
+```javascript
+(async () => {
+    let myResult = await pausable.execute(`
+// Pause at this point for 4 seconds, after which
+// myVar should be assigned the value "my string"
+var myVar = giveMeAfter('my string', 4000);
+
+return myVar + ' with something appended';
+`, {
+    expose: {
+        giveMeAfter(value, milliseconds) {
+            var pause = pausable.createPause();
+
+            setTimeout(() => {
+                // Timeout has elapsed, so we can resume the paused code
+                pause.resume(value);
+            }, milliseconds);
+
+            // Do the pause
+            pause.now();
+        }
+    }
+});
+
+    console.log(myResult);
+})();
+```
+
+Output:
+```
+my string with something appended
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pausable
 
-Pause and resume JavaScript code from arbitrary places.
+Pause and resume JavaScript code from arbitrary points.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pausable
 
+[![Build Status](https://secure.travis-ci.org/asmblah/pausable.png?branch=master)](https://travis-ci.org/asmblah/pausable)
+
 Pause and resume JavaScript code from arbitrary points.
 
 ## Installation

--- a/src/FunctionContext.js
+++ b/src/FunctionContext.js
@@ -98,7 +98,6 @@ _.extend(FunctionContext.prototype, {
         var context = this;
 
         if (context.tryWithFinallyClauseDepth === 0) {
-            context.addVariable('resumableUncaughtError');
             context.tryWithFinallyClause = true;
         }
 

--- a/src/Resumable.js
+++ b/src/Resumable.js
@@ -29,6 +29,8 @@ _.extend(Resumable, {
     PauseException: PauseException,
     ResumeException: ResumeException,
 
+    UNSET: {}, // A sentinel value to use in lieu of adding additional flag variables
+
     /**
      * Checks whether the provided value is callable, throwing a readable error
      * if it is not, to improve the debugging experience

--- a/src/StatementTranspiler/TryStatementTranspiler.js
+++ b/src/StatementTranspiler/TryStatementTranspiler.js
@@ -79,7 +79,18 @@ _.extend(TryStatementTranspiler.prototype, {
 
         if (hasCatch) {
             catchStartIndex = functionContext.getCurrentStatementIndex();
-            catchParameter = functionContext.getTempName();
+            catchParameter = functionContext.getTempName(finalizer ? {
+                'type': Syntax.MemberExpression,
+                'object': {
+                    'type': Syntax.Identifier,
+                    'name': 'Resumable'
+                },
+                'property': {
+                    'type': Syntax.Identifier,
+                    'name': 'UNSET'
+                },
+                'computed': false
+            } : null);
 
             (function () {
                 var catchClauseBlockContext = new BlockContext(functionContext),
@@ -414,8 +425,24 @@ _.extend(TryStatementTranspiler.prototype, {
                     finallyStatements.push({
                         'type': Syntax.IfStatement,
                         'test': {
-                            'type': Syntax.Identifier,
-                            'name': catchParameter
+                            'type': Syntax.BinaryExpression,
+                            'left': {
+                                'type': Syntax.Identifier,
+                                'name': catchParameter
+                            },
+                            'operator': '!==',
+                            'right': {
+                                'type': Syntax.MemberExpression,
+                                'object': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'Resumable'
+                                },
+                                'property': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'UNSET'
+                                },
+                                'computed': false
+                            }
                         },
                         'consequent': {
                             'type': Syntax.BlockStatement,

--- a/src/StatementTranspiler/TryStatementTranspiler.js
+++ b/src/StatementTranspiler/TryStatementTranspiler.js
@@ -56,7 +56,18 @@ _.extend(TryStatementTranspiler.prototype, {
             functionContext.enterTryWithFinallyClause();
 
             if (!handler && !functionContext.hasVariableDefined(UNCAUGHT_ERROR_VARIABLE)) {
-                functionContext.addVariable(UNCAUGHT_ERROR_VARIABLE);
+                functionContext.addVariable(UNCAUGHT_ERROR_VARIABLE, {
+                    'type': Syntax.MemberExpression,
+                    'object': {
+                        'type': Syntax.Identifier,
+                        'name': 'Resumable'
+                    },
+                    'property': {
+                        'type': Syntax.Identifier,
+                        'name': 'UNSET'
+                    },
+                    'computed': false
+                });
             }
         }
 
@@ -324,8 +335,24 @@ _.extend(TryStatementTranspiler.prototype, {
                     finallyStatements.push({
                         'type': Syntax.IfStatement,
                         'test': {
-                            'type': Syntax.Identifier,
-                            'name': UNCAUGHT_ERROR_VARIABLE
+                            'type': Syntax.BinaryExpression,
+                            'left': {
+                                'type': Syntax.Identifier,
+                                'name': UNCAUGHT_ERROR_VARIABLE
+                            },
+                            'operator': '!==',
+                            'right': {
+                                'type': Syntax.MemberExpression,
+                                'object': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'Resumable'
+                                },
+                                'property': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'UNSET'
+                                },
+                                'computed': false
+                            }
                         },
                         'consequent': {
                             'type': Syntax.BlockStatement,

--- a/src/StatementTranspiler/TryStatementTranspiler.js
+++ b/src/StatementTranspiler/TryStatementTranspiler.js
@@ -345,16 +345,29 @@ _.extend(TryStatementTranspiler.prototype, {
                     finallyStatements.push({
                         'type': Syntax.IfStatement,
                         'test': {
-                            /*
-                             * If no value has been returned, the result will be undefined,
-                             * so the default of `undefined` for this var will work fine.
-                             *
-                             * If an error has been thrown, we won't want to cancel that by returning
-                             * from inside the finally clause, but that will have been handled at this point
-                             * by the re-throw just above here.
-                             */
-                            'type': Syntax.Identifier,
-                            'name': 'resumableReturnValue'
+                            'type': Syntax.BinaryExpression,
+                            'left': {
+                                /*
+                                 * If an error has been thrown, we won't want to cancel that by returning
+                                 * from inside the finally clause, but that will have been handled at this point
+                                 * by the re-throw just above here.
+                                 */
+                                'type': Syntax.Identifier,
+                                'name': 'resumableReturnValue'
+                            },
+                            'operator': '!==',
+                            'right': {
+                                'type': Syntax.MemberExpression,
+                                'object': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'Resumable'
+                                },
+                                'property': {
+                                    'type': Syntax.Identifier,
+                                    'name': 'UNSET'
+                                },
+                                'computed': false
+                            }
                         },
                         'consequent': {
                             'type': Syntax.BlockStatement,

--- a/src/StatementTranspiler/TryStatementTranspiler.js
+++ b/src/StatementTranspiler/TryStatementTranspiler.js
@@ -15,10 +15,13 @@ var _ = require('microdash'),
     BlockContext = require('../BlockContext'),
     BLOCK = 'block',
     BODY = 'body',
+    CAUGHT_ERROR_VARIABLE = 'resumableError',
     HANDLER = 'handler',
     FINALIZER = 'finalizer',
     NAME = 'name',
     PARAM = 'param',
+    PAUSE_EXCEPTION_VARIABLE = 'resumablePause',
+    UNCAUGHT_ERROR_VARIABLE = 'resumableUncaughtError',
     Syntax = estraverse.Syntax;
 
 function TryStatementTranspiler(statementTranspiler, expressionTranspiler) {
@@ -37,7 +40,7 @@ _.extend(TryStatementTranspiler.prototype, {
             handler = node[HANDLER],
             catchParam = handler ? handler[PARAM] : {
                 'type': Syntax.Identifier,
-                'name': 'resumableError'
+                'name': CAUGHT_ERROR_VARIABLE
             },
             hasCatch = handler && handler[BODY][BODY].length > 0,
             finalizer = node[FINALIZER],
@@ -52,8 +55,8 @@ _.extend(TryStatementTranspiler.prototype, {
         if (finalizer) {
             functionContext.enterTryWithFinallyClause();
 
-            if (!handler && !functionContext.hasVariableDefined('resumableUncaughtError')) {
-                functionContext.addVariable('resumableUncaughtError');
+            if (!handler && !functionContext.hasVariableDefined(UNCAUGHT_ERROR_VARIABLE)) {
+                functionContext.addVariable(UNCAUGHT_ERROR_VARIABLE);
             }
         }
 
@@ -135,7 +138,7 @@ _.extend(TryStatementTranspiler.prototype, {
                             'type': Syntax.CatchClause,
                             'param': {
                                 'type': Syntax.Identifier,
-                                'name': 'resumableError'
+                                'name': CAUGHT_ERROR_VARIABLE
                             },
                             'body': {
                                 'type': Syntax.BlockStatement,
@@ -145,7 +148,7 @@ _.extend(TryStatementTranspiler.prototype, {
                                         'type': Syntax.BinaryExpression,
                                         'left': {
                                             'type': Syntax.Identifier,
-                                            'name': 'resumableError'
+                                            'name': CAUGHT_ERROR_VARIABLE
                                         },
                                         'operator': 'instanceof',
                                         'right': {
@@ -169,12 +172,12 @@ _.extend(TryStatementTranspiler.prototype, {
                                                 'type': Syntax.AssignmentExpression,
                                                 'left': {
                                                     'type': Syntax.Identifier,
-                                                    'name': 'resumablePause'
+                                                    'name': PAUSE_EXCEPTION_VARIABLE
                                                 },
                                                 'operator': '=',
                                                 'right': {
                                                     'type': Syntax.Identifier,
-                                                    'name': 'resumableError'
+                                                    'name': CAUGHT_ERROR_VARIABLE
                                                 }
                                             }
                                         }, {
@@ -203,7 +206,7 @@ _.extend(TryStatementTranspiler.prototype, {
                                                 'operator': '=',
                                                 'right': {
                                                     'type': Syntax.Identifier,
-                                                    'name': 'resumableError'
+                                                    'name': CAUGHT_ERROR_VARIABLE
                                                 }
                                             }
                                         }]
@@ -212,7 +215,7 @@ _.extend(TryStatementTranspiler.prototype, {
                                     'type': Syntax.ThrowStatement,
                                     'argument': {
                                         'type': Syntax.Identifier,
-                                        'name': 'resumableError'
+                                        'name': CAUGHT_ERROR_VARIABLE
                                     }
                                 }]
                             }
@@ -274,7 +277,7 @@ _.extend(TryStatementTranspiler.prototype, {
                         'type': Syntax.IfStatement,
                         'test': {
                             'type': Syntax.Identifier,
-                            'name': 'resumablePause'
+                            'name': PAUSE_EXCEPTION_VARIABLE
                         },
                         'consequent': {
                             'type': Syntax.BlockStatement,
@@ -282,7 +285,7 @@ _.extend(TryStatementTranspiler.prototype, {
                                 'type': Syntax.ThrowStatement,
                                 'argument': {
                                     'type': Syntax.Identifier,
-                                    'name': 'resumablePause'
+                                    'name': PAUSE_EXCEPTION_VARIABLE
                                 }
                             }]
                         },
@@ -322,7 +325,7 @@ _.extend(TryStatementTranspiler.prototype, {
                         'type': Syntax.IfStatement,
                         'test': {
                             'type': Syntax.Identifier,
-                            'name': 'resumableUncaughtError'
+                            'name': UNCAUGHT_ERROR_VARIABLE
                         },
                         'consequent': {
                             'type': Syntax.BlockStatement,
@@ -330,7 +333,7 @@ _.extend(TryStatementTranspiler.prototype, {
                                 'type': Syntax.ThrowStatement,
                                 'argument': {
                                     'type': Syntax.Identifier,
-                                    'name': 'resumableUncaughtError'
+                                    'name': UNCAUGHT_ERROR_VARIABLE
                                 }
                             }]
                         },
@@ -431,7 +434,7 @@ _.extend(TryStatementTranspiler.prototype, {
                         'type': Syntax.AssignmentExpression,
                         'left': {
                             'type': Syntax.Identifier,
-                            'name': 'resumablePause'
+                            'name': PAUSE_EXCEPTION_VARIABLE
                         },
                         'operator': '=',
                         'right': catchParam
@@ -453,7 +456,7 @@ _.extend(TryStatementTranspiler.prototype, {
                             'type': Syntax.AssignmentExpression,
                             'left': {
                                 'type': Syntax.Identifier,
-                                'name': 'resumableUncaughtError'
+                                'name': UNCAUGHT_ERROR_VARIABLE
                             },
                             'operator': '=',
                             'right': catchParam

--- a/test/unit/FunctionContextTest.js
+++ b/test/unit/FunctionContextTest.js
@@ -24,12 +24,44 @@ describe('FunctionContext', function () {
             this.functionContext.addReturnInTryOutsideFinally();
 
             expect(this.functionContext.hasVariableDefined('resumableReturnValue')).to.be.true;
+            expect(this.functionContext.getVariableValueAST('resumableReturnValue')).to.deep.equal({
+                'type': 'MemberExpression',
+                'object': {
+                    'type': 'Identifier',
+                    'name': 'Resumable'
+                },
+                'property': {
+                    'type': 'Identifier',
+                    'name': 'UNSET'
+                },
+                'computed': false
+            });
         });
 
         it('should not add a `resumableReturnValue` variable to the context when the try does not have a finally clause', function () {
             this.functionContext.addReturnInTryOutsideFinally();
 
             expect(this.functionContext.hasVariableDefined('resumableReturnValue')).to.be.false;
+        });
+    });
+
+    describe('addVariable()', function () {
+        it('should define the variable with a null value AST if not specified', function () {
+            this.functionContext.addVariable('myVar');
+
+            expect(this.functionContext.hasVariableDefined('myVar')).to.be.true;
+            expect(this.functionContext.getVariableValueAST('myVar')).to.be.null;
+        });
+
+        it('should define the variable with the given value AST when specified', function () {
+            this.functionContext.addVariable('myVar', {
+                'type': 'MyNodeType'
+            });
+
+            expect(this.functionContext.hasVariableDefined('myVar')).to.be.true;
+            expect(this.functionContext.getVariableValueAST('myVar')).to.deep.equal({
+                'type': 'MyNodeType'
+            });
         });
     });
 
@@ -53,6 +85,55 @@ describe('FunctionContext', function () {
 
             expect(this.functionContext.isInsideTryWithFinallyClause()).to.be.true;
             expect(this.functionContext.isInsideTryFinallyClause()).to.be.true;
+        });
+    });
+
+    describe('getVariableValueAST()', function () {
+        it('should return null when the variable was defined with no value AST', function () {
+            this.functionContext.addVariable('myVar');
+
+            expect(this.functionContext.getVariableValueAST('myVar')).to.be.null;
+        });
+
+        it('should return the value AST the variable was defined with', function () {
+            this.functionContext.addVariable('myVar', {type: 'MyType'});
+
+            expect(this.functionContext.getVariableValueAST('myVar')).to.deep.equal({type: 'MyType'});
+        });
+
+        it('should throw when the variable is not defined', function () {
+            expect(function () {
+                this.functionContext.getVariableValueAST('myUndefinedVar');
+            }.bind(this)).to.throw('Variable "myUndefinedVar" is not defined');
+        });
+    });
+
+    describe('hasVariableDefined()', function () {
+        it('should return true for a defined variable', function () {
+            this.functionContext.addVariable('myVar');
+
+            expect(this.functionContext.hasVariableDefined('myVar')).to.be.true;
+        });
+
+        it('should return true for a defined function declaration', function () {
+            this.functionContext.addFunctionDeclaration({
+                type: 'FunctionDeclaration',
+                id: {
+                    type: 'Identifier',
+                    name: 'myFunc'
+                },
+                params: [],
+                body: {
+                    type: 'BlockStatement',
+                    body: []
+                }
+            });
+
+            expect(this.functionContext.hasVariableDefined('myFunc')).to.be.true;
+        });
+
+        it('should return false for an undefined variable', function () {
+            expect(this.functionContext.hasVariableDefined('myUndefinedVar')).to.be.false;
         });
     });
 

--- a/test/unit/Resumable/resumeWithThrowTest.js
+++ b/test/unit/Resumable/resumeWithThrowTest.js
@@ -112,7 +112,10 @@ EOS
                     }
                 };
             },
-            expectedError: new Error(21)
+            expectedError: new Error(21),
+            expectedExports: {
+                before: true
+            }
         }
     }, tools.check);
 });

--- a/test/unit/Resumable/tools.js
+++ b/test/unit/Resumable/tools.js
@@ -67,10 +67,17 @@ module.exports = {
             if (scenario.hasOwnProperty('expectedError')) {
                 it('should reject the promise with the correct error', function () {
                     expect(this.error).not.to.be.null;
-                    expect(this.error).to.be.an.instanceOf(
-                        Object.getPrototypeOf(scenario.expectedError).constructor
-                    );
-                    expect(this.error.toString()).to.equal(scenario.expectedError.toString());
+
+                    if (typeof scenario.expectedError === 'object') {
+                        // Expecting an Error instance: check for correct class and message
+                        expect(this.error).to.be.an.instanceOf(
+                            Object.getPrototypeOf(scenario.expectedError).constructor
+                        );
+                        expect(this.error.toString()).to.equal(scenario.expectedError.toString());
+                    } else {
+                        // Expecting a primitive value: check for identity
+                        expect(this.error).to.equal(scenario.expectedError);
+                    }
                 });
             } else {
                 it('should not reject the promise', function () {

--- a/test/unit/Resumable/tryStatementTest.js
+++ b/test/unit/Resumable/tryStatementTest.js
@@ -798,5 +798,38 @@ EOS
                 fifth: 5
             }
         },
+        'returning falsy value from try with only finally': {
+            code: nowdoc(function () {/*<<<EOS
+exports.first = giveMeAsync(1);
+try {
+    exports.second = giveMeAsync(2);
+    return 0;
+    exports.third = 'I should not be reached';
+} finally {
+    exports.fourth = giveMeAsync(4);
+}
+exports.fifth = 'I should not be reached';
+EOS
+*/;}), // jshint ignore:line
+            expose: function (state) {
+                return {
+                    giveMeAsync: function (what) {
+                        var pause = state.resumable.createPause();
+
+                        setTimeout(function () {
+                            pause.resume(what);
+                        });
+
+                        pause.now();
+                    }
+                };
+            },
+            expectedExports: {
+                first: 1,
+                second: 2,
+                fourth: 4
+            },
+            expectedResult: 0
+        }
     }, tools.check);
 });

--- a/test/unit/Resumable/tryStatementTest.js
+++ b/test/unit/Resumable/tryStatementTest.js
@@ -863,6 +863,43 @@ EOS
                 second: 2,
                 fourth: 4
             }
+        },
+        'throwing a new falsy value from catch when there is a finally clause': {
+            code: nowdoc(function () {/*<<<EOS
+exports.first = giveMeAsync(1);
+try {
+    exports.second = giveMeAsync(2);
+    throw new Error('my first error');
+} catch (e) {
+    exports.third = giveMeAsync(3);
+    throw 0;
+    exports.fourth = 'I should not be reached';
+} finally {
+    exports.fifth = giveMeAsync(5);
+}
+exports.sixth = 'I should not be reached';
+EOS
+*/;}), // jshint ignore:line
+            expose: function (state) {
+                return {
+                    giveMeAsync: function (what) {
+                        var pause = state.resumable.createPause();
+
+                        setTimeout(function () {
+                            pause.resume(what);
+                        });
+
+                        pause.now();
+                    }
+                };
+            },
+            expectedError: 0,
+            expectedExports: {
+                first: 1,
+                second: 2,
+                third: 3,
+                fifth: 5
+            }
         }
     }, tools.check);
 });

--- a/test/unit/Resumable/tryStatementTest.js
+++ b/test/unit/Resumable/tryStatementTest.js
@@ -830,6 +830,39 @@ EOS
                 fourth: 4
             },
             expectedResult: 0
+        },
+        'throwing falsy value from try with only finally': {
+            code: nowdoc(function () {/*<<<EOS
+exports.first = giveMeAsync(1);
+try {
+    exports.second = giveMeAsync(2);
+    throw 0;
+    exports.third = 'I should not be reached';
+} finally {
+    exports.fourth = giveMeAsync(4);
+}
+exports.fifth = 'I should not be reached';
+EOS
+*/;}), // jshint ignore:line
+            expose: function (state) {
+                return {
+                    giveMeAsync: function (what) {
+                        var pause = state.resumable.createPause();
+
+                        setTimeout(function () {
+                            pause.resume(what);
+                        });
+
+                        pause.now();
+                    }
+                };
+            },
+            expectedError: 0,
+            expectedExports: {
+                first: 1,
+                second: 2,
+                fourth: 4
+            }
         }
     }, tools.check);
 });

--- a/test/unit/Transpiler/tryStatementTest.js
+++ b/test/unit/Transpiler/tryStatementTest.js
@@ -69,10 +69,20 @@ EOS
                     } else {
                         statementIndex = 3;
                     }
-                    switch (statementIndex) {
-                    case 3:
-                        c = 3;
-                        statementIndex = 4;
+                    try {
+                        switch (statementIndex) {
+                        case 3:
+                            c = 3;
+                            statementIndex = 4;
+                        }
+                    } catch (resumableError) {
+                        if (resumableError instanceof Resumable.PauseException) {
+                            resumablePause = resumableError;
+                            temp0 = e;
+                        } else {
+                            temp0 = resumableError;
+                        }
+                        throw resumableError;
                     }
                 }
                 statementIndex = 4;
@@ -171,13 +181,23 @@ EOS
                     } else {
                         statementIndex = 4;
                     }
-                    switch (statementIndex) {
-                    case 4:
-                        d = 4;
-                        statementIndex = 5;
-                    case 5:
-                        e = 5;
-                        statementIndex = 6;
+                    try {
+                        switch (statementIndex) {
+                        case 4:
+                            d = 4;
+                            statementIndex = 5;
+                        case 5:
+                            e = 5;
+                            statementIndex = 6;
+                        }
+                    } catch (resumableError) {
+                        if (resumableError instanceof Resumable.PauseException) {
+                            resumablePause = resumableError;
+                            temp0 = e;
+                        } else {
+                            temp0 = resumableError;
+                        }
+                        throw resumableError;
                     }
                 }
                 statementIndex = 6;
@@ -306,7 +326,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableUncaughtError, temp0;
+    var statementIndex = 0, temp0;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -343,13 +363,21 @@ EOS
                     } else {
                         statementIndex = 3;
                     }
-                    resumableUncaughtError = e;
-                    switch (statementIndex) {
-                    case 3:
-                        c = 3;
-                        statementIndex = 4;
+                    try {
+                        switch (statementIndex) {
+                        case 3:
+                            c = 3;
+                            statementIndex = 4;
+                        }
+                    } catch (resumableError) {
+                        if (resumableError instanceof Resumable.PauseException) {
+                            resumablePause = resumableError;
+                            temp0 = e;
+                        } else {
+                            temp0 = resumableError;
+                        }
+                        throw resumableError;
                     }
-                    resumableUncaughtError = null;
                 } finally {
                     if (resumablePause) {
                         throw resumablePause;
@@ -362,8 +390,8 @@ EOS
                         d = 4;
                         statementIndex = 5;
                     }
-                    if (resumableUncaughtError) {
-                        throw resumableUncaughtError;
+                    if (temp0) {
+                        throw temp0;
                     }
                 }
                 statementIndex = 5;
@@ -445,9 +473,10 @@ EOS
                 } catch (resumableError) {
                     if (resumableError instanceof Resumable.PauseException) {
                         resumablePause = resumableError;
-                        throw resumableError;
+                    } else {
+                        resumableUncaughtError = resumableError;
                     }
-                    resumableUncaughtError = resumableError;
+                    throw resumableError;
                 } finally {
                     if (resumablePause) {
                         throw resumablePause;
@@ -570,9 +599,10 @@ EOS
                         } catch (resumableError) {
                             if (resumableError instanceof Resumable.PauseException) {
                                 resumablePause = resumableError;
-                                throw resumableError;
+                            } else {
+                                resumableUncaughtError = resumableError;
                             }
-                            resumableUncaughtError = resumableError;
+                            throw resumableError;
                         } finally {
                             if (resumablePause) {
                                 throw resumablePause;
@@ -599,9 +629,10 @@ EOS
                 } catch (resumableError) {
                     if (resumableError instanceof Resumable.PauseException) {
                         resumablePause = resumableError;
-                        throw resumableError;
+                    } else {
+                        resumableUncaughtError = resumableError;
                     }
-                    resumableUncaughtError = resumableError;
+                    throw resumableError;
                 } finally {
                     if (resumablePause) {
                         throw resumablePause;
@@ -692,9 +723,10 @@ EOS
                 } catch (resumableError) {
                     if (resumableError instanceof Resumable.PauseException) {
                         resumablePause = resumableError;
-                        throw resumableError;
+                    } else {
+                        resumableUncaughtError = resumableError;
                     }
-                    resumableUncaughtError = resumableError;
+                    throw resumableError;
                 } finally {
                     if (resumablePause) {
                         throw resumablePause;
@@ -725,6 +757,133 @@ EOS
                     func: resumableScope,
                     statementIndex: statementIndex + 1,
                     assignments: {}
+                });
+            }
+            throw e;
+        }
+    }.apply(this, arguments);
+});
+EOS
+*/;}), // jshint ignore:line
+            ast = acorn.parse(inputJS, {'allowReturnOutsideFunction': true});
+
+        ast = transpiler.transpile(ast);
+
+        expect(escodegen.generate(ast, {
+            format: {
+                indent: {
+                    style: '    ',
+                    base: 0
+                }
+            }
+        })).to.equal(expectedOutputJS);
+    });
+
+    it('should correctly transpile when there is a return inside the catch clause with finally', function () {
+        var inputJS = nowdoc(function () {/*<<<EOS
+a = 1;
+try {
+    b = 2;
+} catch (e) {
+    return 'my result';
+} finally {
+    c = 3;
+}
+d = 4;
+EOS
+*/;}), // jshint ignore:line
+            expectedOutputJS = nowdoc(function () {/*<<<EOS
+(function () {
+    var statementIndex = 0, resumableReturnValue, temp0;
+    return function resumableScope() {
+        var resumablePause = null;
+        if (Resumable._resumeState_) {
+            statementIndex = Resumable._resumeState_.statementIndex;
+            temp0 = Resumable._resumeState_.temp0;
+            Resumable._resumeState_ = null;
+        }
+        try {
+            switch (statementIndex) {
+            case 0:
+                a = 1;
+                statementIndex = 1;
+            case 1:
+                statementIndex = 2;
+            case 2:
+            case 3:
+            case 4:
+                try {
+                    switch (statementIndex) {
+                    case 2:
+                        b = 2;
+                        statementIndex = 3;
+                        break;
+                    case 3:
+                        throw new Resumable.ResumeException(temp0);
+                    }
+                } catch (e) {
+                    if (e instanceof Resumable.PauseException) {
+                        resumablePause = e;
+                        throw e;
+                    }
+                    if (e instanceof Resumable.ResumeException) {
+                        e = e.error;
+                    } else {
+                        statementIndex = 3;
+                    }
+                    try {
+                        switch (statementIndex) {
+                        case 3:
+                            return resumableReturnValue = 'my result';
+                            statementIndex = 4;
+                        }
+                    } catch (resumableError) {
+                        if (resumableError instanceof Resumable.PauseException) {
+                            resumablePause = resumableError;
+                            temp0 = e;
+                        } else {
+                            temp0 = resumableError;
+                        }
+                        throw resumableError;
+                    }
+                } finally {
+                    if (resumablePause) {
+                        throw resumablePause;
+                    }
+                    if (statementIndex >= 2 && statementIndex < 4) {
+                        statementIndex = 4;
+                    }
+                    switch (statementIndex) {
+                    case 4:
+                        c = 3;
+                        statementIndex = 5;
+                    }
+                    if (resumableReturnValue) {
+                        return resumableReturnValue;
+                    }
+                    if (temp0) {
+                        throw temp0;
+                    }
+                }
+                statementIndex = 5;
+            case 5:
+                d = 4;
+                statementIndex = 6;
+            }
+        } catch (e) {
+            if (e instanceof Resumable.PauseException) {
+                e.add({
+                    func: resumableScope,
+                    statementIndex: statementIndex + 1,
+                    assignments: {},
+                    catches: {
+                        3: {
+                            from: 2,
+                            to: 2,
+                            param: 'temp0'
+                        }
+                    },
+                    temp0: temp0
                 });
             }
             throw e;
@@ -785,9 +944,10 @@ EOS
                 } catch (resumableError) {
                     if (resumableError instanceof Resumable.PauseException) {
                         resumablePause = resumableError;
-                        throw resumableError;
+                    } else {
+                        resumableUncaughtError = resumableError;
                     }
-                    resumableUncaughtError = resumableError;
+                    throw resumableError;
                 } finally {
                     if (resumablePause) {
                         throw resumablePause;

--- a/test/unit/Transpiler/tryStatementTest.js
+++ b/test/unit/Transpiler/tryStatementTest.js
@@ -326,7 +326,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, temp0;
+    var statementIndex = 0, temp0 = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -390,7 +390,7 @@ EOS
                         d = 4;
                         statementIndex = 5;
                     }
-                    if (temp0) {
+                    if (temp0 !== Resumable.UNSET) {
                         throw temp0;
                     }
                 }
@@ -794,7 +794,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, temp0;
+    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, temp0 = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -861,7 +861,7 @@ EOS
                     if (resumableReturnValue !== Resumable.UNSET) {
                         return resumableReturnValue;
                     }
-                    if (temp0) {
+                    if (temp0 !== Resumable.UNSET) {
                         throw temp0;
                     }
                 }

--- a/test/unit/Transpiler/tryStatementTest.js
+++ b/test/unit/Transpiler/tryStatementTest.js
@@ -698,7 +698,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableReturnValue, resumableUncaughtError;
+    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, resumableUncaughtError;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -742,7 +742,7 @@ EOS
                     if (resumableUncaughtError) {
                         throw resumableUncaughtError;
                     }
-                    if (resumableReturnValue) {
+                    if (resumableReturnValue !== Resumable.UNSET) {
                         return resumableReturnValue;
                     }
                 }
@@ -794,7 +794,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableReturnValue, temp0;
+    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, temp0;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -858,7 +858,7 @@ EOS
                         c = 3;
                         statementIndex = 5;
                     }
-                    if (resumableReturnValue) {
+                    if (resumableReturnValue !== Resumable.UNSET) {
                         return resumableReturnValue;
                     }
                     if (temp0) {

--- a/test/unit/Transpiler/tryStatementTest.js
+++ b/test/unit/Transpiler/tryStatementTest.js
@@ -448,7 +448,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableUncaughtError;
+    var statementIndex = 0, resumableUncaughtError = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -489,7 +489,7 @@ EOS
                         c = 3;
                         statementIndex = 4;
                     }
-                    if (resumableUncaughtError) {
+                    if (resumableUncaughtError !== Resumable.UNSET) {
                         throw resumableUncaughtError;
                     }
                 }
@@ -549,7 +549,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableUncaughtError;
+    var statementIndex = 0, resumableUncaughtError = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -617,7 +617,7 @@ EOS
                             case 8:
                                 throw 'inner';
                             }
-                            if (resumableUncaughtError) {
+                            if (resumableUncaughtError !== Resumable.UNSET) {
                                 throw resumableUncaughtError;
                             }
                         }
@@ -648,7 +648,7 @@ EOS
                         return 'my final result';
                         statementIndex = 12;
                     }
-                    if (resumableUncaughtError) {
+                    if (resumableUncaughtError !== Resumable.UNSET) {
                         throw resumableUncaughtError;
                     }
                 }
@@ -698,7 +698,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, resumableUncaughtError;
+    var statementIndex = 0, resumableReturnValue = Resumable.UNSET, resumableUncaughtError = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -739,7 +739,7 @@ EOS
                         c = 3;
                         statementIndex = 4;
                     }
-                    if (resumableUncaughtError) {
+                    if (resumableUncaughtError !== Resumable.UNSET) {
                         throw resumableUncaughtError;
                     }
                     if (resumableReturnValue !== Resumable.UNSET) {
@@ -919,7 +919,7 @@ EOS
 */;}), // jshint ignore:line
             expectedOutputJS = nowdoc(function () {/*<<<EOS
 (function () {
-    var statementIndex = 0, resumableUncaughtError;
+    var statementIndex = 0, resumableUncaughtError = Resumable.UNSET;
     return function resumableScope() {
         var resumablePause = null;
         if (Resumable._resumeState_) {
@@ -960,7 +960,7 @@ EOS
                         c = 3;
                         statementIndex = 4;
                     }
-                    if (resumableUncaughtError) {
+                    if (resumableUncaughtError !== Resumable.UNSET) {
                         throw resumableUncaughtError;
                     }
                 }


### PR DESCRIPTION
- Fix issue when throwing a new error inside catch clause with finally
- Fix issue with returning a falsy value from try..finally when finally clause pauses
- Fix issue when throwing a falsy value from try with only finally clause and no catch clause
- Fix issue with throwing a new falsy value from catch when there is a finally clause